### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/tokenauth/helpers.py
+++ b/tokenauth/helpers.py
@@ -16,7 +16,8 @@ def email_login_link(request, email):
     # Create the signed structure containing the time and email address.
     email = email.lower().strip()
     data = {"t": int(time.time()), "e": email}
-    data = Signer().sign(base64.b64encode(json.dumps(data).encode("utf8")))
+    data = json.dumps(data).encode("utf8")
+    data = Signer().sign(base64.b64encode(data).decode("utf8"))
 
     # Send the link by email.
     send_mail(

--- a/tokenauth/views.py
+++ b/tokenauth/views.py
@@ -16,7 +16,7 @@ class EmailForm(forms.Form):
 
 
 def token_post(request):
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         messages.error(request, _("You are already logged in."))
         return redirect(ta_settings.LOGIN_REDIRECT)
 


### PR DESCRIPTION
This PR makes the project Django 2.0 compatible.

Two issues resolved:
* request.user.is_authenticated as of Django 1.10 is also an attribute. As of Django 2.0 is only an attribute (boolean).
* Signer().sign() used to return a utf8 string if given a bytestring (eg `test:signature`). As of Django 2.0 if given a bytestring it returns a bytestring along with utf8 signature (eg. `b'test':signature`). Thus, I added a utf8 decoding to the base64.b64encode result in order to provide a utf8 string to the sign function. This is important because the template render function escapes single quotes.

These changes are not compatible with Django <1.10.