### PR TITLE
Support for Django 2.1

### DIFF
--- a/tokenauth/auth_backends.py
+++ b/tokenauth/auth_backends.py
@@ -12,7 +12,7 @@ class EmailTokenBackend:
         except User.DoesNotExist:
             return None
 
-    def authenticate(self, token=None):
+    def authenticate(self, request, token=None):
         """Authenticate a user given a signed token."""
         AuthToken.delete_stale()
 

--- a/tokenauth/views.py
+++ b/tokenauth/views.py
@@ -51,7 +51,7 @@ def token_post(request, token):
         messages.error(request, _("You are already logged in."))
         return redirect(ta_settings.LOGIN_REDIRECT)
 
-    user = authenticate(token=token)
+    user = authenticate(request, token=token)
     if user is None:
         messages.error(request, _("The login link was invalid or has expired. Please try to log in again."))
         return redirect(ta_settings.LOGIN_URL)


### PR DESCRIPTION
It seems this library is broken for Django 2.1: https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1

`The authenticate() method of authentication backends requires request as the first positional argument.`

I changed the `authenticate` to have `request` as first argument. There might a better way since the `request` variable isn't used in the body of the function.

Tested with Django 2.0 also, seems to work fine.