### PR TITLE
fix: Support Django 4.2, and add a pile of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.egg
 *.egg-info
 local_settings.py
+.venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 23.3.0
+  rev: 23.10.1
   hooks:
   - id: black
 - repo: https://github.com/asottile/reorder_python_imports

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ is only valid for a few minutes (and one login) is generated and sent in an
 email. The user clicks on the link and is immediately logged in, and the token
 is invalidated.
 
+django-tokenauth requires Django 4.2 or newer. If you using an older version
+of Django, consider using v0.5.3 or earlier of this package.
+
 [![PyPI version](https://img.shields.io/pypi/v/django-tokenauth.svg)](https://pypi.python.org/pypi/django-tokenauth)
 
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ is only valid for a few minutes (and one login) is generated and sent in an
 email. The user clicks on the link and is immediately logged in, and the token
 is invalidated.
 
-django-tokenauth requires Django 4.2 or newer. If you using an older version
-of Django, consider using v0.5.3 or earlier of this package.
-
 [![PyPI version](https://img.shields.io/pypi/v/django-tokenauth.svg)](https://pypi.python.org/pypi/django-tokenauth)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 import getpass
 import os
 
-import pytest
 from django.conf import settings
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,57 @@
+import getpass
+import os
+
+import pytest
+from django.conf import settings
+
+
+def pytest_configure():
+    settings.configure(
+        DATABASES={
+            "default": {
+                "ENGINE": os.environ.get(
+                    "TOKENAUTH_DB_BACKEND", "django.db.backends.postgresql"
+                ),
+                "NAME": os.environ.get("TOKENAUTH_DB_NAME", "tokenauth_test"),
+                "USER": os.environ.get("TOKENAUTH_DB_USER", getpass.getuser()),
+                "PASSWORD": os.environ.get("TOKENAUTH_DB_PASSWORD"),
+            }
+        },
+        TIME_ZONE="UTC",
+        INSTALLED_APPS=[
+            # Django apps
+            "django.contrib.admin",
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "django.contrib.messages",
+            "django.contrib.sessions",
+            "tokenauth",
+        ],
+        ROOT_URLCONF="tests.urls",
+        ALLOWED_HOSTS=["*"],
+        LANGUAGE_CODE="en",
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "context_processors": [
+                        "django.contrib.auth.context_processors.auth",
+                        "django.template.context_processors.i18n",
+                        "django.contrib.messages.context_processors.messages",
+                        "django.template.context_processors.request",
+                    ]
+                },
+            }
+        ],
+        AUTHENTICATION_BACKENDS=[
+            "tokenauth.auth_backends.EmailTokenBackend",
+            "django.contrib.auth.backends.ModelBackend",
+        ],
+        MIDDLEWARE=[
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ],
+        SECRET_KEY="KNOWN_FIXED_VALUE_IS_FINE_FOR_TESTS",
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,7 @@ def pytest_configure():
             }
         },
         TIME_ZONE="UTC",
+        USE_TZ=True,
         INSTALLED_APPS=[
             # Django apps
             "django.contrib.admin",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     keywords="django",
     zip_safe=False,
     include_package_data=True,
-    packages=find_namespace_packages(),
+    packages=find_namespace_packages(exclude=("tests",)),
     extras_require={
         "test": [
             "django",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             "django",
             "black==23.10.1",
             "factory-boy==3.3.0",
+            "pre-commit==3.5.0",
             "psycopg2-binary==2.8.6",
             "pytest==7.4.3",
             "pytest-django==4.5.2",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     extras_require={
         "test": [
             "django",
+            "black==23.10.1",
             "factory-boy==3.3.0",
             "psycopg2-binary==2.9.9",
             "pytest==7.4.3",

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,13 @@ setup(
     zip_safe=False,
     include_package_data=True,
     packages=find_namespace_packages(),
+    extras_require={
+        "test": [
+            "django",
+            "factory-boy==3.3.0",
+            "psycopg2-binary==2.9.9",
+            "pytest==7.4.3",
+            "pytest-django==4.5.2",
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from tokenauth import __version__
 
-assert sys.version >= "2.7", "Requires Python v2.7 or above."
+assert sys.version_info >= (3, 8), "Requires Python v3.8 or above."
 from distutils.core import setup  # noqa
 from setuptools import find_namespace_packages  # noqa
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             "django",
             "black==23.10.1",
             "factory-boy==3.3.0",
-            "psycopg2-binary==2.9.9",
+            "psycopg2-binary==2.8.6",
             "pytest==7.4.3",
             "pytest-django==4.5.2",
         ],

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,11 @@
+import factory
+from django.contrib.auth import get_user_model
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+
+    username = factory.Sequence(lambda i: f"user{i}")
+    email = factory.Sequence(lambda i: f"imaginary{i}@example.invalid")
+    password = factory.django.Password("password")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,6 +1,8 @@
 import factory
 from django.contrib.auth import get_user_model
 
+from tokenauth.models import AuthToken
+
 
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
@@ -9,3 +11,10 @@ class UserFactory(factory.django.DjangoModelFactory):
     username = factory.Sequence(lambda i: f"user{i}")
     email = factory.Sequence(lambda i: f"imaginary{i}@example.invalid")
     password = factory.django.Password("password")
+
+
+class AuthTokenFactory(factory.django.DjangoModelFactory):
+    email = factory.Sequence(lambda i: f"imaginary{i}@example.invalid")
+
+    class Meta:
+        model = AuthToken

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,9 @@
+from django.contrib.messages import get_messages
+
+
+def messages(response):
+    return list(get_messages(response.wsgi_request))
+
+
+def message_texts(response):
+    return [message.message for message in messages(response)]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,8 +1,9 @@
 import pytest
 from django.urls import reverse
 
+from tests.factories import AuthTokenFactory
+from tests.factories import UserFactory
 from tokenauth.models import AuthToken
-from tests.factories import AuthTokenFactory, UserFactory
 
 
 @pytest.mark.django_db

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,40 @@
+import pytest
+from django.urls import reverse
+
+from tokenauth.models import AuthToken
+from tests.factories import AuthTokenFactory, UserFactory
+
+
+@pytest.mark.django_db
+def test_auth_token_admin_works(client):
+    """
+    This is somewhat covered by Django being Django. Nevertheless, let's
+    ensure that we have not done something to break the admin in future.
+    """
+    tokens = AuthTokenFactory.create_batch(10)
+    client.force_login(UserFactory(is_staff=True, is_superuser=True))
+    response = client.get(reverse("admin:tokenauth_authtoken_changelist"))
+    assert response.status_code == 200
+
+    response = client.get(
+        reverse("admin:tokenauth_authtoken_change", args=[tokens[0].pk])
+    )
+    assert response.status_code == 200
+
+    response = client.get(
+        reverse("admin:tokenauth_authtoken_change", args=[tokens[0].pk])
+    )
+    assert response.status_code == 200
+
+    response = client.get(reverse("admin:tokenauth_authtoken_add"))
+    assert response.status_code == 200
+
+    response = client.post(
+        reverse("admin:tokenauth_authtoken_add"),
+        data={
+            "email": "createit@example.invalid",
+            "token": "abcdef",
+        },
+    )
+    assert response.status_code == 302
+    assert AuthToken.objects.count() == 11

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -2,8 +2,8 @@ import sys
 
 import pytest
 
-from tokenauth.auth_backends import EmailTokenBackend
 from tests.factories import UserFactory
+from tokenauth.auth_backends import EmailTokenBackend
 
 
 @pytest.mark.django_db

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -1,0 +1,15 @@
+import sys
+
+import pytest
+
+from tokenauth.auth_backends import EmailTokenBackend
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_emailtoken_backend_get_user():
+    user = UserFactory()
+    backend = EmailTokenBackend()
+    assert backend.get_user(user.pk) == user
+    assert backend.get_user(None) is None
+    assert backend.get_user(sys.maxsize) is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -37,7 +37,7 @@ def test_email_login_link(client):
 
     response = client.get(path)
     assert response.status_code == 302
-    assert response.headers["Location"] == "/wat/"
+    assert response["Location"] == "/wat/"
     assert message_texts(response) == ["Login successful."]
     # Make sure we've actually logged in.
     assert client.get("/authenticated/").content == b"authenticated"
@@ -73,7 +73,7 @@ def test_email_login_link_with_new_email(client):
 
     response = client.get(path)
     assert response.status_code == 302
-    assert response.headers["Location"] == "/accounts/profile/"
+    assert response["Location"] == "/accounts/profile/"
     assert message_texts(response) == ["Your email address has been changed."]
 
     # Has the email address changed?

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,81 @@
+from urllib.parse import urlparse
+
+import pytest
+from django.core import mail
+from django.test import RequestFactory
+
+from tests.factories import UserFactory
+from tests.helpers import message_texts
+from tokenauth.helpers import email_login_link
+from tokenauth.models import AuthToken
+
+
+@pytest.mark.django_db
+def test_email_login_link(client):
+    # paranoia about test pollution
+    assert AuthToken.objects.count() == 0
+
+    email_login_link(
+        RequestFactory().get("/"), "imaginary@example.invalid", next_url="/wat/"
+    )
+    assert len(mail.outbox) == 1
+    sent_mail = mail.outbox[0]
+    assert sent_mail.to == ["imaginary@example.invalid"]
+    assert sent_mail.subject == "Your login link"
+    assert sent_mail.body.startswith("Hello!")
+
+    token = AuthToken.objects.get()
+    assert token.next_url == "/wat/"
+    assert token.email == "imaginary@example.invalid"
+    assert token.token
+
+    # Make sure the link in the email does what we think it does.
+    url = next(
+        line for line in sent_mail.body.split("\n") if line.startswith("https://")
+    )
+    path = urlparse(url).path
+
+    response = client.get(path)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/wat/"
+    assert message_texts(response) == ["Login successful."]
+    # Make sure we've actually logged in.
+    assert client.get("/authenticated/").content == b"authenticated"
+
+
+@pytest.mark.django_db
+def test_email_login_link_with_new_email(client):
+    user = UserFactory(email="imaginary@example.invalid")
+
+    # paranoia about test pollution again
+    assert AuthToken.objects.count() == 0
+
+    email_login_link(
+        RequestFactory().get("/"),
+        "imaginary@example.invalid",
+        new_email="imaginary2@example.invalid",
+    )
+    assert len(mail.outbox) == 1
+    sent_mail = mail.outbox[0]
+    assert sent_mail.to == ["imaginary2@example.invalid"]
+    assert sent_mail.subject == "Please confirm your email address change"
+    assert sent_mail.body.startswith("Hello!")
+
+    token = AuthToken.objects.get()
+    assert token.email == "imaginary@example.invalid"
+    assert token.token
+
+    # Make sure the link in the email does what we think it does.
+    url = next(
+        line for line in sent_mail.body.split("\n") if line.startswith("https://")
+    )
+    path = urlparse(url).path
+
+    response = client.get(path)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/accounts/profile/"
+    assert message_texts(response) == ["Your email address has been changed."]
+
+    # Has the email address changed?
+    user.refresh_from_db()
+    assert user.email == "imaginary2@example.invalid"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,13 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_no_migrations_need_creating():
+    stdout = StringIO()
+    stderr = StringIO()
+    call_command("makemigrations", "--check", "--dry-run", stderr=stderr, stdout=stdout)
+    assert stderr.getvalue() == ""
+    assert "No changes detected" in stdout.getvalue()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,4 +2,15 @@ from tokenauth.models import EmailLog, generate_token
 
 
 def test_emaillog_str():
-    assert str(EmailLog(email='example@example.invalid')) == 'example@example.invalid'
+    assert str(EmailLog(email="example@example.invalid")) == "example@example.invalid"
+
+
+def test_generate_token():
+    # No really interesting tests we can do here; just make sure it's
+    # returning something.
+    token = generate_token()
+    assert isinstance(token, str)
+    assert len(token) == 8
+
+    # ...and that we haven't done something terminally bad.
+    assert generate_token() != token

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,5 @@
+from tokenauth.models import EmailLog, generate_token
+
+
+def test_emaillog_str():
+    assert str(EmailLog(email='example@example.invalid')) == 'example@example.invalid'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,10 @@
-from tokenauth.models import EmailLog, generate_token
+from datetime import timedelta
+
+import pytest
+from django.utils.timezone import now
+
+from tests.factories import AuthTokenFactory
+from tokenauth.models import AuthToken, EmailLog, generate_token
 
 
 def test_emaillog_str():
@@ -14,3 +20,17 @@ def test_generate_token():
 
     # ...and that we haven't done something terminally bad.
     assert generate_token() != token
+
+
+@pytest.mark.django_db
+def test_authtoken_delete_stale():
+    expired_token = AuthTokenFactory()
+    # creating with `timestamp` kwarg doesn't actually work (probably because
+    # of auto_now_add)
+    expired_token.timestamp = now() - timedelta(days=1)
+    expired_token.save()
+    alive_token = AuthTokenFactory()
+
+    AuthToken.delete_stale()
+    assert AuthToken.objects.count() == 1
+    assert AuthToken.objects.get() == alive_token

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,9 @@ import pytest
 from django.utils.timezone import now
 
 from tests.factories import AuthTokenFactory
-from tokenauth.models import AuthToken, EmailLog, generate_token
+from tokenauth.models import AuthToken
+from tokenauth.models import EmailLog
+from tokenauth.models import generate_token
 
 
 def test_emaillog_str():

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_authenticated_view_works(client):
+    # Self-test for our testing "authenticated" view. We depend on it in tests
+    # so it is a good idea to make sure it works.
+    response = client.get("/authenticated/")
+    assert response.status_code == 200
+    assert response.content == b"unauthenticated"
+
+    client.force_login(UserFactory())
+    response = client.get("/authenticated/")
+    assert response.content == b"authenticated"
+    assert response.status_code == 200

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,17 @@
+import datetime
 import pytest
 from django.core import mail
 from django.urls import reverse
+from django.utils.timezone import is_aware, now as django_now
 
+from tokenauth.views import awarify
 from tests.factories import UserFactory
 from tests.helpers import message_texts
+
+
+def test_awarify():
+    assert is_aware(awarify(datetime.datetime.now())) is True
+    assert is_aware(awarify(django_now())) is True
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,8 +4,9 @@ from django.core import mail
 from django.urls import reverse
 from django.utils.timezone import is_aware, now as django_now
 
+from tokenauth.models import AuthToken
 from tokenauth.views import awarify
-from tests.factories import UserFactory
+from tests.factories import AuthTokenFactory, UserFactory
 from tests.helpers import message_texts
 
 
@@ -41,3 +42,69 @@ def test_email_post_successful(client):
         "Login email sent! Please check your inbox and click on the link to be logged in."
     ]
     assert len(mail.outbox) == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("use_next_url", ["/wat/", ""])
+def test_token_post_works(client, use_next_url):
+    token = AuthTokenFactory(email=UserFactory().email, next_url=use_next_url)
+    response = client.get(
+        reverse("tokenauth:login-token", kwargs={"token": token.token})
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"] == use_next_url or "/"
+    assert message_texts(response) == ["Login successful."]
+    assert client.get("/authenticated/").content == b"authenticated"
+
+
+@pytest.mark.django_db
+def test_token_post_already_authenticated(client):
+    user = UserFactory()
+    token = AuthTokenFactory(email=user.email)
+    client.force_login(user)
+    response = client.get(
+        reverse("tokenauth:login-token", kwargs={"token": token.token})
+    )
+    assert response.status_code == 302
+    assert message_texts(response) == ["You are already logged in."]
+
+
+@pytest.mark.django_db
+def test_token_post_with_junk_token(client):
+    response = client.get(reverse("tokenauth:login-token", kwargs={"token": "hurf"}))
+    assert response.status_code == 302
+    assert message_texts(response) == [
+        "The login link is invalid or has expired, or you are not allowed to log in. Please try again."
+    ]
+    assert client.get("/authenticated/").content == b"unauthenticated"
+
+
+@pytest.mark.django_db
+def test_token_post_with_expired_token(client):
+    token = AuthTokenFactory(email=UserFactory().email)
+    token.timestamp = django_now() - datetime.timedelta(seconds=3600 * 24 * 365)
+    token.save()
+
+    response = client.get(
+        reverse("tokenauth:login-token", kwargs={"token": token.token})
+    )
+    assert response.status_code == 302
+
+    assert message_texts(response) == [
+        "The login link is invalid or has expired, or you are not allowed to log in. Please try again."
+    ]
+
+    # Check that the expired token has been deleted.
+    assert AuthToken.objects.count() == 0
+
+    # Check that we haven't actually logged in.
+    assert client.get("/authenticated/").content == b"unauthenticated"
+
+
+@pytest.mark.django_db
+def test_logout(client):
+    client.force_login(UserFactory())
+    assert client.get("/authenticated/").content == b"authenticated"
+    response = client.get(reverse("tokenauth:logout"))
+    assert message_texts(response) == ["You have been logged out."]
+    assert client.get("/authenticated/").content == b"unauthenticated"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,35 @@
+import pytest
+from django.core import mail
+from django.urls import reverse
+
+from tests.factories import UserFactory
+from tests.helpers import message_texts
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("post_data", [{}, {"email": "hurrr"}])
+def test_email_post_invalid_emails(client, post_data):
+    response = client.post(reverse("tokenauth:login"), data=post_data)
+    assert response.status_code == 302
+    assert message_texts(response) == [
+        "The email address was invalid. Please check the address and try again."
+    ]
+
+
+@pytest.mark.django_db
+def test_email_post_when_already_logged_in(client):
+    client.force_login(UserFactory())
+    response = client.post(reverse("tokenauth:login"))
+    assert response.status_code == 302
+    assert message_texts(response) == ["You are already logged in."]
+
+
+@pytest.mark.django_db
+def test_email_post_successful(client):
+    user = UserFactory()
+    response = client.post(reverse("tokenauth:login"), data={"email": user.email})
+    assert response.status_code == 302
+    assert message_texts(response) == [
+        "Login email sent! Please check your inbox and click on the link to be logged in."
+    ]
+    assert len(mail.outbox) == 1

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -52,7 +52,7 @@ def test_token_post_works(client, use_next_url):
         reverse("tokenauth:login-token", kwargs={"token": token.token})
     )
     assert response.status_code == 302
-    assert response.headers["Location"] == use_next_url or "/"
+    assert response["Location"] == use_next_url or "/"
     assert message_texts(response) == ["Login successful."]
     assert client.get("/authenticated/").content == b"authenticated"
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,13 +1,16 @@
 import datetime
+
 import pytest
 from django.core import mail
 from django.urls import reverse
-from django.utils.timezone import is_aware, now as django_now
+from django.utils.timezone import is_aware
+from django.utils.timezone import now as django_now
 
+from tests.factories import AuthTokenFactory
+from tests.factories import UserFactory
+from tests.helpers import message_texts
 from tokenauth.models import AuthToken
 from tokenauth.views import awarify
-from tests.factories import AuthTokenFactory, UserFactory
-from tests.helpers import message_texts
 
 
 def test_awarify():

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,15 @@
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("auth/", include("tokenauth.urls", namespace="tokenauth")),
+    path(
+        "authenticated/",
+        lambda request: HttpResponse(
+            "authenticated" if request.user.is_authenticated else "unauthenticated"
+        ),
+    ),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.http import HttpResponse
-from django.urls import include, path
+from django.urls import include
+from django.urls import path
 
 
 urlpatterns = [

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,6 @@
+from django.urls import include, path
+
+
+urlpatterns = [
+    path("auth/", include("tokenauth.urls", namespace="tokenauth")),
+]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,8 @@
+from django.contrib import admin
 from django.urls import include, path
 
 
 urlpatterns = [
+    path("admin/", admin.site.urls),
     path("auth/", include("tokenauth.urls", namespace="tokenauth")),
 ]

--- a/tokenauth/auth_backends.py
+++ b/tokenauth/auth_backends.py
@@ -8,11 +8,7 @@ from .models import generate_token
 class EmailTokenBackend:
     def get_user(self, user_id):
         """Get a user by their primary key."""
-        User = get_user_model()
-        try:
-            return User.objects.get(pk=user_id)
-        except User.DoesNotExist:
-            return None
+        return get_user_model().objects.filter(pk=user_id).first()
 
     def authenticate(self, request, token=None):
         """Authenticate a user given a signed token."""

--- a/tokenauth/models.py
+++ b/tokenauth/models.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.db import models
 from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
 
 from . import settings as ta_settings
 
@@ -49,7 +50,9 @@ class AuthToken(models.Model):
     email = models.CharField(max_length=2000)
     new_email = models.CharField(
         max_length=2000,
-        help_text="The email address that the user's email will be set to when they use this token.",
+        help_text=_(
+            "The email address that the user's email will be set to when they use this token."
+        ),
         blank=True,
     )
     next_url = models.CharField(max_length=2000, blank=True)

--- a/tokenauth/models.py
+++ b/tokenauth/models.py
@@ -1,4 +1,4 @@
-import random
+import secrets
 from datetime import timedelta
 
 from django.db import models
@@ -10,7 +10,7 @@ from . import settings as ta_settings
 def generate_token():
     return "".join(
         [
-            random.choice("abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+            secrets.choice("abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789")
             for _ in range(ta_settings.TOKEN_LENGTH)
         ]
     )

--- a/tokenauth/tests.py
+++ b/tokenauth/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase  # noqa
-
-# Create your tests here.

--- a/tokenauth/urls.py
+++ b/tokenauth/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
 app_name = "tokenauth"
 urlpatterns = [
-    url(r"^login/$", views.email_post, name="login"),
-    url(r"^login/(?P<token>\w+)/$", views.token_post, name="login-token"),
-    url(r"^logout/$", views.logout, name="logout"),
+    path("login", views.email_post, name="login"),
+    path("login/<str:token>/", views.token_post, name="login-token"),
+    path("logout/", views.logout, name="logout"),
 ]

--- a/tokenauth/views.py
+++ b/tokenauth/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.utils.timezone import is_aware
 from django.utils.timezone import make_aware
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
 
 from . import settings as ta_settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist={py38,py39,py310,py311}-django42
 
 [testenv]
+allowlist_externals=pytest
 basepython=
     py38: python3.8
     py39: python3.9
@@ -9,4 +10,5 @@ basepython=
     py311: python3.11
 deps=
     django42: django==4.2.6
-commands=python setup.py test
+extras = test
+commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ deps=
 extras = test
 commands =
   pytest
-  black --check .
+  pre-commit run -a --hook-stage=manual

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,6 @@ basepython=
 deps=
     django42: django==4.2.6
 extras = test
-commands = pytest
+commands =
+  pytest
+  black --check .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist={py38,py39,py310,py311}-django42
+envlist={py38,py39,py310,py311}-{django22,django32,django42}
 
 [testenv]
 allowlist_externals=pytest
@@ -9,6 +9,8 @@ basepython=
     py310: python3.10
     py311: python3.11
 deps=
+    django22: django==2.2.28
+    django32: django==3.2.22
     django42: django==4.2.6
 extras = test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist={py27,py34,py35,py36}-django{20,30}
+envlist={py38,py39,py310,py311}-django42
 
 [testenv]
 basepython=
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
     py38: python3.8
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
 deps=
-    django20: django==2.0
-    django30: django==3.0
+    django42: django==4.2.6
 commands=python setup.py test


### PR DESCRIPTION
Alright! So I was looking at your imgz service (I'm a paying user, I like it!), and thinking that could really do with being updated to a modern Django version, and this package got in the way of that. Let's fix it! It probably doesn't support anything less than 4.2 with this PR, but 3.2 is out of support in a few months and anyone who needs this upgrade is probably going all the way to 4.2.

But, while I'm there...

To have any confidence that I wasn't completely breaking it, I've added a pile of tests, with fancy factories and everything. I wrote them to use Pytest, because that is what I use at my day job, and because I like it. It has 94% coverage now. That's 6% less than I would like, but there are some branches that are tricky to test (there are conditional imports, and the settings being done with `getattr` on `django.conf.settings` once at import time means you can't use `override_settings` to test those branches). The important ones are tested though; logging in works, sending emails works, the URLs in the emails work, logging out works.

Also, while I'm there, it was using `random` to generate the secrets. That is not secure. It is not secure in ways that are probably very hard to exploit with network timing getting in the way. It is still better to use `secrets` instead, so I did.

P.S. I'm on Python 3.10 here; I didn't actually test it with any of the other Python versions in `tox.ini`. But I don't see much reason they won't work!